### PR TITLE
Add torch to build-system.requires in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "torch"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fix `ModuleNotFoundError: No module named 'torch'` during build step.

```python
Traceback (most recent call last):
  File "<string>", line 14, in <module>
  File "/home/user/project//.uvcache/builds-v0/.tmpthM1ag/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=[])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/project//.uvcache/builds-v0/.tmpthM1ag/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
    self.run_setup()
  File "/home/user/project//.uvcache/builds-v0/.tmpthM1ag/lib/python3.12/site-packages/setuptools/build_meta.py", line 512, in run_setup
    super().run_setup(setup_script=setup_script)
  File "/home/user/project//.uvcache/builds-v0/.tmpthM1ag/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
    exec(code, locals())
  File "<string>", line 9, in <module>
ModuleNotFoundError: No module named 'torch'
```

References:
- https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#build-system-requirement